### PR TITLE
[WIP] Finite Duration Bias

### DIFF
--- a/notebooks/reducing_duration_bias.ipynb
+++ b/notebooks/reducing_duration_bias.ipynb
@@ -7,18 +7,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "import sys\n",
     "import warnings\n",
+    "import contextlib\n",
     "from itertools import combinations\n",
     "from tqdm.notebook import tqdm\n",
-    "import matplotlib.pyplot as plt\n",
+    "from timeit import default_timer as timer\n",
     "\n",
+    "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
     "from neurodsp.spectral import compute_spectrum\n",
-    "\n",
     "from timescales.sim import sim_spikes_synaptic\n",
     "from timescales.fit import convert_knee_val, fit_psd\n",
-    "from timescales.optimize import fit_grid"
+    "from timescales.optimize import fit_grid\n",
+    "\n",
+    "# abcTau\n",
+    "sys.path.append('/home/rph/Projects/abcTau')\n",
+    "sys.path.append('/home/rph/Projects/abcTau/abcTau')\n",
+    "import abcTau\n",
+    "from abcTau import distance_functions\n",
+    "from scipy import stats"
    ]
   },
   {
@@ -50,18 +60,24 @@
     "        \n",
     "    return knee_freq\n",
     "\n",
-    "def fit_grid_no_warnings(sig, fs, grid, max_n_params=int(1e3)):\n",
+    "def _fit_grid(sig, fs, grid, max_n_params=int(1e3), return_time=False):\n",
     "    \n",
     "    with warnings.catch_warnings():\n",
     "        \n",
     "        warnings.simplefilter(\"ignore\")\n",
     "        \n",
+    "        start = timer()\n",
     "        params = fit_grid(sig, fs, grid, mode='psd', max_n_params=max_n_params,\n",
     "                          n_jobs=-1, chunksize=20)\n",
+    "        end = timer()\n",
     "        \n",
     "        knees = np.array([p[1] for p in params])\n",
+    "        time = end - start\n",
     "        \n",
-    "    return knees"
+    "    if return_time:\n",
+    "        return knees, time\n",
+    "    else:\n",
+    "        return knees"
    ]
   },
   {
@@ -75,7 +91,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "cc9dded020774dfaae9e19b2addcbdfd",
+       "model_id": "1d95ef4e20b74ed8a7b1bd0938a1e32a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -89,7 +105,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e5ba0385ab8b49dc8d207093d70f3a04",
+       "model_id": "f422402896d4429f9ca485f0e81af852",
        "version_major": 2,
        "version_minor": 0
       },
@@ -103,7 +119,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "813d80f6a6d44781a0441b1d86dbb298",
+       "model_id": "87893405ba274c4abe3f250653a68302",
        "version_major": 2,
        "version_minor": 0
       },
@@ -126,6 +142,9 @@
     "for ind, n_seconds in enumerate(n_seconds_params):\n",
     "    \n",
     "    for n in tqdm(range(n_iters)):\n",
+    "        \n",
+    "        # Generate timeseries\n",
+    "        #   Note: this isn't stored to limit memory usage\n",
     "        np.random.seed(seed_ind)\n",
     "        seed_ind += 1\n",
     "                  \n",
@@ -146,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "id": "1c7807b0",
    "metadata": {},
    "outputs": [
@@ -156,7 +175,7 @@
        "Text(0.5, 0, 'Seconds')"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -220,14 +239,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 6,
    "id": "adf9397c",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0c4ae83e43e64168ac754d6ea1e2aa0f",
+       "model_id": "b77f014e058640d99db073be93b8a968",
        "version_major": 2,
        "version_minor": 0
       },
@@ -242,8 +261,10 @@
    "source": [
     "fs = 1000\n",
     "n_iters = 100\n",
+    "max_n_params = int(1e3)\n",
     "\n",
-    "knee_freqs_grid = np.zeros((n_iters, int(1e3)))\n",
+    "knee_freqs_grid = np.zeros((n_iters, max_n_params))\n",
+    "times = np.zeros(n_iters)\n",
     "\n",
     "seed_ind = 0\n",
     "for n in tqdm(range(n_iters), total=n_iters):\n",
@@ -253,12 +274,16 @@
     "\n",
     "    probs, _ = sim_spikes_synaptic(1, fs, convert_knee_val(10))\n",
     "\n",
-    "    knee_freqs_grid[n] = fit_grid_no_warnings(probs, fs, specparam_grid, max_n_params=int(1e3))"
+    "    _knee_freq, _time = _fit_grid(probs, fs, specparam_grid, max_n_params=max_n_params,\n",
+    "                                  return_time=True)\n",
+    "    \n",
+    "    knee_freqs_grid[n] = _knee_freq\n",
+    "    times[n] = _time"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 7,
    "id": "620421ed",
    "metadata": {
     "scrolled": true
@@ -270,7 +295,7 @@
        "Text(0.5, 0, 'Seconds')"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -301,7 +326,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 8,
    "id": "3f10d168",
    "metadata": {},
    "outputs": [
@@ -311,7 +336,7 @@
        "Text(0.5, 0, 'Seconds')"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -339,6 +364,282 @@
     "plt.ylim(0, 60)\n",
     "plt.ylabel('Tau (hertz)')\n",
     "plt.xlabel('Seconds')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0c7d92c6",
+   "metadata": {},
+   "source": [
+    "### Comparison with abcTau\n",
+    "\n",
+    "The random grid search above is compared with the abcTau approach below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6cc6997a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "630ec7335f5a4fba9f8d30bb3bd833dd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/100 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "sigs = np.zeros((n_iters, int(fs)))\n",
+    "\n",
+    "seed_ind = 0\n",
+    "for n in tqdm(range(n_iters), total=n_iters):\n",
+    "\n",
+    "    np.random.seed(seed_ind)\n",
+    "    seed_ind += 1\n",
+    "\n",
+    "    probs, _ = sim_spikes_synaptic(1, fs, convert_knee_val(10))\n",
+    "    sigs[n] = probs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "0e4d517c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# creating model object\n",
+    "class ABCModel(abcTau.Model):\n",
+    "\n",
+    "    #This method initializes the model object.  \n",
+    "    def __init__(self):\n",
+    "        pass\n",
+    "        \n",
+    "    # draw samples from the prior. \n",
+    "    def draw_theta(self):\n",
+    "        theta = []\n",
+    "        for p in self.prior:\n",
+    "            theta.append(p.rvs())\n",
+    "        return theta\n",
+    "\n",
+    "    # Choose the generative model (from generative_models)\n",
+    "    # Choose autocorrelation computation method (from basic_functions)\n",
+    "    def generate_data(self, theta):\n",
+    "        # generate synthetic data\n",
+    "        if disp == None:\n",
+    "            syn_data, numBinData =  eval('abcTau.generative_models.' + generativeModel + \\\n",
+    "                                         '(theta, deltaT, binSize, T, numTrials, data_mean, data_var)')\n",
+    "        else:\n",
+    "            syn_data, numBinData =  eval('abcTau.generative_models.' + generativeModel + \\\n",
+    "                                         '(theta, deltaT, binSize, T, numTrials, data_mean, data_var, disp)')\n",
+    "               \n",
+    "        # compute the summary statistics\n",
+    "        syn_sumStat = abcTau.summary_stats.comp_sumStat(syn_data, summStat_metric, ifNorm, deltaT, binSize, T,\\\n",
+    "                                          numBinData, maxTimeLag)   \n",
+    "        return syn_sumStat\n",
+    "\n",
+    "    # Computes the summary statistics\n",
+    "    def summary_stats(self, data):\n",
+    "        sum_stat = data\n",
+    "        return sum_stat\n",
+    "\n",
+    "    # Choose the method for computing distance (from basic_functions)\n",
+    "    def distance_function(self, data, synth_data):\n",
+    "        if np.nansum(synth_data) <= 0: # in case of all nans return large d to reject the sample\n",
+    "            d = 10**4\n",
+    "        else:\n",
+    "            d = eval('distance_functions.' +distFunc + '(data, synth_data)')        \n",
+    "        return d\n",
+    "    \n",
+    "    \n",
+    "def fit_abc(ABCModel, sigs, priors, epsilon_0, min_samples, steps,\n",
+    "            min_acceptance_rate, parallel, n_procs, disp):\n",
+    "\n",
+    "    taus = np.zeros(len(sigs))\n",
+    "    times = np.zeros(len(sigs))\n",
+    "    \n",
+    "    for ind, sig in tqdm(enumerate(sigs), total=len(sigs)):\n",
+    "        \n",
+    "        _sig = np.array([sig])\n",
+    "        \n",
+    "        # Hack\n",
+    "        global data_mean\n",
+    "        global data_var\n",
+    "        global trial_duration\n",
+    "        global num_trials\n",
+    "        \n",
+    "        # Summary stats\n",
+    "        summary_stats, data_mean, data_var, trial_duration, num_trials =  \\\n",
+    "            abcTau.preprocessing.extract_stats(_sig, deltaT, binSize,\n",
+    "                                               summStat_metric, ifNorm, maxTimeLag)\n",
+    "        \n",
+    "        # Fit\n",
+    "        with open(os.devnull, \"w\") as f, contextlib.redirect_stdout(f):\n",
+    "            start = timer()\n",
+    "            abc_results, final_step = abcTau.fit.fit_withABC(ABCModel, summary_stats, priors, inter_save_direc,\n",
+    "                                                             inter_filename, datasave_path, filenameSave, epsilon_0,\n",
+    "                                                             min_samples, steps, min_acceptance_rate, parallel,\n",
+    "                                                             n_procs, disp)\n",
+    "            end = timer()\n",
+    "        \n",
+    "        taus[ind] =  (abc_results[final_step-1][0] / fs).mean()\n",
+    "        times[ind] = end - start\n",
+    "    \n",
+    "    return taus, times"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "154b643d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Setup output directories required for abcTau\n",
+    "def clean_mkdir(path):\n",
+    "    dirs = path.split('/')\n",
+    "\n",
+    "    dir_path = ''\n",
+    "    for d in dirs:\n",
+    "        if len(d) == 0:\n",
+    "            continue\n",
+    "        \n",
+    "        if dir_path == '':\n",
+    "            dir_path = d\n",
+    "        else:\n",
+    "            dir_path = dir_path + '/' + d\n",
+    "        \n",
+    "        if not os.path.isdir(dir_path):\n",
+    "            os.mkdir(dir_path)\n",
+    "            \n",
+    "\n",
+    "datasave_path = 'abc/example_abc_results/'\n",
+    "inter_save_direc = 'abc/example_abc_results/'\n",
+    "inter_filename = 'abc_intermediate_results'\n",
+    "filenameSave = 'simulation'\n",
+    "\n",
+    "for path in [datasave_path, inter_save_direc]:\n",
+    "    clean_mkdir(path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "44c8f10e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# abcTau settings\n",
+    "summStat_metric = 'comp_psd'\n",
+    "deltaT = 1\n",
+    "binSize = 1\n",
+    "disp = None \n",
+    "maxTimeLag = 50\n",
+    "ifNorm = True\n",
+    "generativeModel = 'oneTauOU'\n",
+    "distFunc = 'linear_distance'\n",
+    "epsilon_0 = 1\n",
+    "min_samples = 100\n",
+    "steps = 60\n",
+    "min_acceptance_rate = 0.1\n",
+    "parallel = True\n",
+    "n_procs = 12\n",
+    "numTrials = 1\n",
+    "numTimePoints = len(sigs[0])\n",
+    "T = numTimePoints* deltaT\n",
+    "\n",
+    "# Uniform Priors\n",
+    "t_min = 0.0\n",
+    "t_max = 100.0\n",
+    "priors = [stats.uniform(loc=t_min, scale = t_max - t_min)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "3d9fbf3e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "8415f5979c8341389a39ca7cde58c9f0",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "  0%|          | 0/100 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Fit\n",
+    "taus_abs, times_abc = fit_abc(ABCModel, sigs, priors, epsilon_0, min_samples,\n",
+    "                         steps, min_acceptance_rate, parallel, n_procs, disp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "69777c19",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5, 0, 'Method')"
+      ]
+     },
+     "execution_count": 32,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAt8AAAGVCAYAAAAmIZ1TAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjUuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/YYfK9AAAACXBIWXMAAAsTAAALEwEAmpwYAABqrElEQVR4nO3deZwkdX3/8ddn7p2Z3Z2dndkDWNgFlkNR0WxQYlQMioomiBqPRAWCQY3mp0YT0ajgfSSe8cSIQBTUxAMUFBHFE4QVV06BZVnY+5r7nun+/P6oGunt7Znpnumuo/v9fDz60TNV1VWfqe2t/vS3Pt/v19wdERERERGpvLq4AxARERERqRVKvkVEREREIqLkW0REREQkIkq+RUREREQiouRbRERERCQiSr5FRERERCKi5FukAszsMjNzM1sbdywiIlK6ariOh/HfFHcccjAl31Ky8D9zKY9zY4rz3CJi2zrPfV8cvv60sgZdQWa2Noz5srhjEZHZmdkJZvZfZnaXmfWb2YSZ7TSza83sfDNrjjvGqJnZTWZWtslJ0nQdz/kiUOzjprhjlpk1xB2ApNJ7Cyx7M7AU+DTQl7duU2XDmdMfgO/NsK6vQsd8B/ARYEeF9i8iVcrM3gNcRNBAdjNwOTAErAROA/4beD2wIaYQa0WSruPfA7bmLTsNeAbwc+CmvHXT254IjFQsKpkXJd9SMne/OH9Z2Lq9FPiUu2+NOKS5bCoUcyW5+y5gV5THFJH0M7N3EjRwbAP+1t1/W2CbFwBvjTq2WpOk67i7f4+8RiQzu5gg+b5pps84d/9jhUOTeVDZiVSUmb3QzL5mZveb2XD4+J2Z/T8zO+T9N9ttxZwyknMrGO/jzewqM9tqZuNmts/MbjezT5lZY7jNVoJWKYCf5d7qy9nPIbWCuWUfZnaMmf2fmR0ws0Ez+7GZnRRu121ml5jZLjMbM7PbzOyZBWI9zMzeY2a/NrPdObelrzSzx+RtezHwUPjrObOVBZnZc8zsOjPbH56DB83sP8ysYz7nS0SKE14vLgYmgTMLJd4A7v4D4LkFXv9SM/tFWKYyamZ3mtk7CpWohP9nt5pZu5l90sy2ha/ZZGYvDLdpMLN/N7MHwmvRg2b2xgL7Oi28llxsZqea2U/CGAbN7HozO6SFvtA1stD+ps9LeH19Rvh7wfIKM3tmeO28x8wGwr/nLjO7yMxa8v9+5nEdX+C5bguvpY+E18vNZvZ2M7P815RL/jkKl/2p3MbMXmHBZ/JI+Pnxiem/wcz+yoLP5AEz6zWz/zGz5TMc5wgz+6yZbQn/tgNmdo2Z/Xml/rY0U8u3VNpHgCzwW4Jbd0uBvyIoT/lz4FXxhXYwM3s8QZwOXEOQrC4BjgX+CXgXwYfip4AXEnwQXM6htwLnsjY8zr3AZeHvZwM3mdmpwI+AAeCbQCfwcuCHZnacuz+Ss5+nAxcCPwO+TXBbej3wEuBvzOyp7v6HcNubgA7gTRxahrMp5xxcRPDh3wP8ANgLPB54G3CmmZ3q7gPhtsWeLxEpznlAI/ANd79rtg3dfTz3dzP7EEGZxH7gSoLrwfOADwHPMbMz3H0ibzeNwA0E15mrgSbgFcC3zewMgv/HTwZ+CIwDfwv8l5ntc/dvFgjryWEMPwE+R3AteBHw9PD4vyzqLByqj+BuwLnAURxc+rg15+e3AycAvwGuBVqApxJc004zs2e5eybc9lPM8zq+gHN9PXAYwfmcCo//kTDOQuWclfbPBHF/j+Az4gzgLUCnmV0NfIPgPF4C/AXwSqArfM2fmNmTgB8TvI+uB74TbvdC4Fdmdra7X1fxvyZN3F0PPRb8ILhwObA2b/kxBbatI7jYOfDkvHU3BW/Lgsc4N3zNuUXGNL39JoKLb6HHc3O2/3i4/VkF9rUMqMv5/eJw29NmOPZl+eeDIMn28PHvedu/O1zeA3wx71ivCtd9Mu81K4DFBY79BIIPgx/mLZ8+/mUzxPzMcP1vgI4ZzuUnc5YVfb700EOPuR/AjeH/qdeU+LpTw9c9AqzKWd4AfD9c986810xfs78PNOcsf1rOtei23GsBcDQwAfw+b1+n5Vzb3pi37qxw+QN517VDrpEF9ndx3vKbmOHzISc+K7D8/eH+Xpa3fD7X8YWc6+uARTnLVxB8segDGufxfpmO/+JZtnGCspRCr+sHTsxZ3gzcDWSAA8AzctbVEXxRc+DkvL97MzCWu3247jCCRrddue8xPVxlJ1JZ7v5ggWVZgpZvgOdEEMYTCG4vFnoccusWGM1f4O69YdzlsJWgtSPX5eFzM/Cvece6kqCV5OS8mPa6+2CBWP8A/BR4ZomlH/8vfP5Hd+/L2+dlBF9i/r7A6yp9vkRqxerweXuJr/uH8PkD7r57eqG7TxHUhmeB18zw2jd7Tiu6B63TDxF8gX577rXA3bcAvwZOMrP6AvvaDHw+d4G7X03QIfBYgsS+Ytx9i4dZX55Phs/l+LxZyLn+f+4+mvOavQR3HJYCx5chtlJ9xt3vzYlnnOCOax1wrbv/PGddFvha+OsTcvbxfOAY4L9ytw9fsxP4GLAKOL0if0FKqexEKiqsD/tX4EyCVom2vE0OjyCMy9393CK2+yZBWcb3zOz/CG6d/rrQF4gF2uSP3vqctjN8vj8/oXb3jJntAY7I35GZPR94HcGoB10c+n+6i+I7DJ1KUCbyt2b2twXWNwHdZrbc3Q8Q3fkSkdk9KXz+af4Kd7/fzLYD68xsqbv356zum+H/605gHfC7Aut2EFxnVnHoKCC/nOFL900E5R1PJEjEK8LM2giuSWcDxwGLgdx66nJ83sz3XPe7++YC+9sWPi8rQ2yl2lhg2fRn0Uz/9nDwZ9Gp4fNR0zX6edaHzycStPwLSr6lgizooHcbwUX8VuAKgluZUzxaf5yYsWrd/VYzexrw7wR1068CMLP7gPe6+1VlOlR//gJ3nwr73ByyLjRFUDP4J2b2JoK6xV6C24GPEAwp5QS1dk+gtPO7nOCacNEc27UDByI8XyK1YhdBklJqkrg05/Uz7fdIguvuQQnhDNtPAeQljwetI+96FNozw/6mW4iXzrB+wcK7fD8FTgHuImgc2Mej/U4uojyfN/M9130zbD99PgvdSai02f59i/23n+6AWajBJld7CXFVPSXfUkmvIUi83+t5wyCFHQvfVOA12XB9Q3gbL1dHBWI8iLvfDLwg7O39ZwRlKf8MXBl2MvpJpWMohpk1ENTt7Qae5MGQWLnrTy30ujn0E9Rkdhb7grScL5GU+BVBh/TTga+U8LrpRGkVUKgle3XedpWycoblqwocf7qFvFAe0jGPY59FkHhf5u7n5a4ws9XM3ahQrKSc66SY/jvPcvdrYo0kRVTzLZV0bPj87QLrnjHDa3rD5zUF1kU2oYS7j7v7b9z9PTxaC31WzibTZSNxtFZAUE7SAfymQOLdzqO3RnPNFfMtwDIze2ypwRRxvkRkbl8laKl9seUNF5ovb0i734fPpxXY7liCMoGH8vtyVMBfWoEhZHPi+n3Osvlc6zMAM9SbT3/efKfAupk+b+ZzHU/KuU6KW8LnitbzVxsl31JJW8Pn03IXmtkTCYZpKuTW8Pkf815zOsEQWBVjZn9hZosKrJpuzcmdJexA+HxkJWOaxV6CeP4sTLaBP916/TRBcp6vl6AkZaaYpzslfdnMDstfGY5R+5Sc30s5XyIyBw8mKLuYoH/FtVZgfGwAM3suwXB10y4Nn99lZt0529UD/0nwWV9KS/p8rScYnvBPzOwsguR3M5A71OBM1/rHUfiuKMx+3d0aPp+Wt7+jgY/OY38zScq5ToqrCe4AvMHMziy0gQVjv7dGG1ayqexEKukKgs6Wn7JgkpgHCC7OLyBonXhZgdd8NXzNO8zsCcA9BB1nngd8F3jxPOI4eYaOIMBBM3b+G/BXZjbd238IeGx47F6CsU6n/YzgtumHLZgcpzfc1wfmEV/J3D1rZp8hGOf7znBM1iaC4QI7w/iemfeaITP7LfA0M/s6cD9By8817n6Hu99oZhcCHwYeMLPrCM5DO8HYus8guC0+PUJMKedLRIrg7h8Ky8ouAm4zs98QdIybnl7+6QTX0Y05r/mNmX2M4P/kXWEH6GGC/4snEfy//Y8Iwv8R8HEzex7BfALT43yPAf+Q1xnzaoLPhFeY2REEcwYcSXDH7GrgpQX2fyNBbfF3wuvTKPCwu/8PwTB/m4F/CRP434f7ewHBWNWFEuySr+MJOteJ4O6TZvYigvG9rw3fr5sIGl/WEMzncTRBOY4aZKbFPdahHtXxYOZxvh9DMAHLXoIL1O8IasHXMsOY0wQJ3HXAIMEHzk0Eid+5zG+c71kfOdufQZD830NQxzYM3Ad8BjiqwP5fSXCRGS2wr8vyz8dsf3O4/pDxWPPO79a8ZQ3Av4TxjhLUf/8PQaJ8yPHD1xxL8CF1gOBD55DzCfwl8C2CXu8TBJ2WNgGfADbM93zpoYcexT8IOl7+F0HnwYHw/+Iughbv8ykwbjLBhFy/Cq+dYwRjNv870FJg20OuKTnrbsq9nuWtK3RtOy1cdjHB6Bc/CWMeJJh85c9n2Ncago6RPeE17DaCZP1P+8vbvp5gIpstBOU5B10zw/19nWBUjtHw7/+38FpZ8PpKidfxCpzri5llrPE53iPTr714lm0O+btnOyazfM7O9O8SrltBMITuXQRJ9hDBl6v/C89xQ9z/p5L0sPCkiYiIiJTMzE4jaEU+pHO9iBxKNd8iIiIiIhFR8i0iIiIiEhEl3yIiIiIiEVHNt4iIiIhIRNTyLSIiIiISkZoa57urq8vXrl0bdxgiIiX73e9+t9/du+fesnromi0iaTXbNbumku+1a9eycePGuTcUEUkYM3s47hiipmu2iKTVbNdslZ2IiIiIiEREybeIiIiISESUfIuIiIiIRETJt4iIiIhIRJR8i4iIiIhEJLbk28zWmNnPzOweM7vbzN4ULu80sxvM7IHwedkMrz8n3OYBMzsn2uhFREREREoXZ8v3FPBWd38M8BTgDWb2GOBC4EZ3Xw/cGP5+EDPrBC4CngycAlw0U5IuIiIiIpIUsSXf7r7L3W8Pfx4E7gUOB84CLg83uxx4YYGXPwe4wd173L0XuAF4bsWDFhERERFZgETUfJvZWuCJwG+Ble6+K1y1G1hZ4CWHA9tyft8eLhMRERERSazYk28zawe+DbzZ3Qdy17m7A77A/V9gZhvNbOO+ffsWsisRERERkQWJNfk2s0aCxPvr7v6dcPEeM1sdrl8N7C3w0h3AmpzfjwiXHcLdL3H3De6+obu7u3zBi4iIiIiUqCGuA5uZAV8B7nX3T+SsugY4B/hI+Hx1gZdfD3wop5PlGcA7KhiuiMzHV58fdwTzc961cUcgIhI9XbMjEVvyDTwVeBVwp5ltCpe9kyDp/paZnQ88DLwUwMw2AK9z99e4e4+ZvR+4LXzd+9y9J9LoRSRa2SnITAQ/778/eO46Lniub4K6OC9nIiJykOwkZCaDn/Ov2WbQsCieuBIgtk8rd/8VYDOsPr3A9huB1+T8filwaWWiE5GyKGdrRO9W2Htv8PON7w2en/FvwfPKx0LHkeU7lohILSrnNXvP3dD3SPBz/jUbg/XPhrr68h0vRWLvcCkiUpSpiZnXTbeuiIhIMowNzLLSYXy29dVNybeIpENmluR7ajy6OEREZHbuMD44+zazJufVTcm3iKTDbMn3bOtERCRaE0Pgmdm3Ucu3iEjCZafmt05ERKJVTKv2WH/l40goJd8ikg5q+RYRSYdiEuvxIchmKx9LAin5FpF0mK1TpTpciogkR1ElJbXb6VLJt4ikg5JvEZHkcy++M2WNlp4o+RaR5MtmZ++8k50MLvgiIhKvYjpbTlPLt4hIQhXToTJb5MVeREQqp5QhBNXyLSKSUNkiykqK2UZERCqrlIR6fKgmG06UfItI8hVT0626bxGR+JXUml2bnS6VfItI8hVVdqKxvkVEYpXNlp5M12DpiZJvEUk+Jd8iIsk3MQhe4tjdo30VCSXJlHyLSPIp+RYRSb75tGKr5VtEJIGUfIuIJN98WrEnR2quz46SbxFJvmJ6wyv5FhGJ13xbsWus9VvJt4gkX1HJd+0NVyUikhiZyWCCnfkY7S1vLAmn5FtEkk+T7MTCzNaY2c/M7B4zu9vM3hQuv9jMdpjZpvBxZs5r3mFmm83sPjN7Ts7y54bLNpvZhXH8PSJSQQtpva6xTpcNcQcgIjKnYqYqLnY6YynFFPBWd7/dzBYDvzOzG8J1n3T3/8zd2MweA7wceCxwGPATMzsuXP054NnAduA2M7vG3e+J5K8Qkcob6Zn/a8f6wB3MyhZOkin5FpHkU4fLWLj7LmBX+POgmd0LHD7LS84CvuHu48BDZrYZOCVct9ndtwCY2TfCbZV8i1SLhZSOZKeC8cFblpYvngRT2YmIJF+2iHFjVXZSUWa2Fngi8Ntw0RvN7A4zu9TMloXLDge25bxse7hspuWFjnOBmW00s4379u0r558gIpWSzQat1wuxkJbzlFHyLSLJV1TZSYkTO0jRzKwd+DbwZncfAL4AHAOcTNAy/vFyHcvdL3H3De6+obu7u1y7FZFKGutb+DV4tHaSb5WdiEjyabST2JhZI0Hi/XV3/w6Au+/JWf9l4AfhrzuANTkvPyJcxizLRSTtytFqPdJbM3XfavkWkeRTh8tYmJkBXwHudfdP5CxfnbPZ2cBd4c/XAC83s2YzWwesB24FbgPWm9k6M2si6JR5TRR/g4hEYOTAwveRnQzqvmuAWr5FJPmKadVW2UklPBV4FXCnmW0Kl70TeIWZnQw4sBV4LYC7321m3yLoSDkFvME9+FZkZm8ErgfqgUvd/e7o/gwRqZhsZuH13tNGDtREp0sl3yKSfMW0aqvspOzc/VdAoXvA183ymg8CHyyw/LrZXiciKTXSU77Gj+ED0Hl0efaVYCo7EZHkK+bCrrITEZHojewv375Ge2qiIUXJt4gkX1FDDarsREQkcsNlHBLUszUx5KCSbxFJvqJavpV8i4hEanIUJobLu89yJvMJpeRbRJItmyXo1zcHlZ2IiESrEomykm8RkZiV0qKt0hMRkegMVSBRnhwpf2t6wij5FpFkK6VFW63fIiLRyGbLM753IUN7K7PfhIhtqEEzuxR4AbDX3U8Kl30TOD7cpAPoc/eTC7x2KzAIZIApd98QQcgiEodSer5nM1DfWLlYREQkMNpTuQaP4f3Qua4y+06AOMf5vgz4LHDF9AJ3f9n0z2b2caB/ltc/093LOL6NiCRSKWUn6nQpIhKNSrZOTw85WFdfuWPEKLayE3f/BVBwPJlwSuOXAldFGpSIJI/KTkREkqeSHSO9giUtCZDUmu+nAXvc/YEZ1jvwYzP7nZldEGFcIhK1UstORESksiaGg46RlVTFdd9JnV7+Fcze6v2X7r7DzFYAN5jZH8OW9EOEyfkFAEceeWT5IxWRylLZiYhIskQxHGA5Z85MmMS1fJtZA/Ai4JszbePuO8LnvcB3gVNm2fYSd9/g7hu6u7vLHa6IVFp2qjLbiojI/AxHUBJSiQl8EiJxyTfwLOCP7r690EozazOzxdM/A2cAd0UYn4hESWUnIiLJUckhBvNV6YQ7sSXfZnYVcDNwvJltN7Pzw1UvJ6/kxMwOM7Prwl9XAr8ysz8AtwLXuvuPoopbRCKmlm8RkeQY64uuc3sULewxiK3m291fMcPycwss2wmcGf68BXhCRYMTkeRQ8i0ikhzDEdZij/YELe11SSzUmL/q+mtEpPqUUkqiDpciIpUV5RCA2SkYn23Kl3RS8i0iyVZKa3ZmsnJxiIjUuswUjEWcDI8UnBIm1ZR8i0iyqexERCQZRnsJplqJUBVOtqPkW0SSLVtCa3Yp24qISGniSIRHe4O67yqS1El2asLLvnTzvF6XdcfL8MXTDOrM5vXab7721IUHIFKMTCllJ2r5FhGpmDiSb88GI6y0dkZ/7ApR8p1CY5MZxqdm/xa4rSeY9nVNZ+uM2zTV19HWrLeAJJxavkVE4peZhPGBeI49ckDJt5THfFuPf/PgfkbGZx8B4mPX/xGAf3vOCTNu09xYx9PWa9ZPSbjMRGW2FRGR4sVZez1yAFgf3/HLTDXfKTOZyc6ZeBdrfDLL2KRmBJSEK2UEE5WdiIhURpTje+cb7auq67uS75QZGivvm2+wzPsTKatsprSxu7OTVdcxR0QkEUZiTL7xqhr1RMl3ypQ7WR4cU42sJNjUeOmvUemJiEh5jQ/C5Gi8MQzvjff4ZaTkO2UGx8ubLA+Nq+VbEiwzn+R7Hq8REZGZDSUg8R3aS1mGeksAJd8pU+6yEyXfkmhT82jFns9rRERkZoO7444guKs52ht3FGWh5DtF3J2RifJ2kBydyJDNVsc3SalCU2PRvEZERAobH4pviMF8AzvijqAslHynyPhUlkyZE2V3GNGIJ5JUqvkWEYlXkhLewd1BR/yUU/KdIsMVKhEZUemJJNV8WrHj7hQkIlItslno3xZ3FI/KTsHAzrijWDAl3ylS7pKTSu9XZMHm0/I9n9eIiMihBnaUNtdCFHq3xh3Bgin5TpHRCpWHKPmWxJocKf01U2r5FhFZMHfo2RJ3FIeaGILBPXFHsSBKvlNktEJJcqWSepEFcVfZiYhIXAZ2zq8BJAoHNqd62EEl3ylSqSRZU8xLIk2Nlza75bTslIYbFBFZiGwG9t8fdxQzGx9Ide23ku8UqWTy7Sn+BilVaiEtLkltrRERSYOeh5I/bOv++yCTzgEjlHynxGQmSyZTmQTZPRjGUCRRlHyLiERvYhh6How7irlNjcOBB+KOYl6UfKdEpeuyK1VPLjJvE8PxvFZEpFa5w+4751fyF4ferTDSE3cUJVPynRJjFU6O1elSEmdiKJ7XiojUqp4t6ZvCffcdqSs/UfKdEhVv+VbyLUmjlm8RkeiM9MD+FJZxTI7CnjvjjqIkSr5TotJjcavsRBIlm4WJBdRtTwynehgqEZFITY3Drk1ASq+bg7tTNfmOku+UUMu31JSJIRb0IeBZdboUESlGNgs7f5/+2YH3/hGGD8QdRVGUfKfEyHhlk2PNcimJUo6a7fHBhe9DRKTa7bkrfXXeBXnwJSIFZYdKvlMgk/WKT4QzOZVlQsMNSlKMDSRjHyIi1Wz/ZhjYEXcU5ZOdhO23JX6iNSXfKTAyEU0v3qiOIzKn8TIkzuXYh4hIterbltpxsmc1OQo7NiZ6BBQl3ykwNB7NGyiq44jMqSwt3/0L34eISDUa3AN77o47isoZ6w9KULLJvKOv5DsFhpV8Sy2ZGA5uHS5UZgImEz49sohI1IYPpHtkk2KN7Ifdf0jkyFdKvlOgfzSapHhwTMm3JEA5W6zV+i0i8qjRPth5e3pmsFyowd1Bh9KEUfKdAoNjZWgFLPI42WzyviFKjSlr8t1Xvn2JiKTZ2ABs3wjZGmto698Oe++NO4qDxJZ8m9mlZrbXzO7KWXaxme0ws03h48wZXvtcM7vPzDab2YXRRR294fEppjLRJMTZLAyq9ETiVs4hr6pi+CwRkQUaHwpGASlHSV8a9W5N1OydcbZ8XwY8t8DyT7r7yeHjuvyVZlYPfA54HvAY4BVm9piKRhqj3pFoh8vpH6nR/5iSDNlMeYcIHOtPbIcbEZFITIzA9luDfjC17MBm6NkSdxRAjMm3u/8C6JnHS08BNrv7FnefAL4BnFXW4BKkL+JkuCfiZF/kIKN9lLUTkGdVeiIitWtyLBz3OuWzV5bLvvug75G4o0hkzfcbzeyOsCxlWYH1hwPbcn7fHi4ryMwuMLONZrZx37595Y61otydA8PRJsO9IxOq+5b4jM7n+/hc+1TpyXyZ2Roz+5mZ3WNmd5vZm8LlnWZ2g5k9ED4vC5ebmX0mLAm8w8yelLOvc8LtHzCzc+L6m0RqRiaccGZyJO5IkmXP3TCwM9YQkpZ8fwE4BjgZ2AV8fKE7dPdL3H2Du2/o7u5e6O4iNTg+xWTEs05mMk7/qEpPJCYjFUi+K7HP2jEFvNXdHwM8BXhDWOZ3IXCju68Hbgx/h6AccH34uIDgmo6ZdQIXAU8muHt50QyNKyJSDtlM0LlyYijuSJJp1x0wFF+DbKKSb3ff4+4Zd88CXya4SOfbAazJ+f2IcFnV2TcYz22ifUO6PSUxyFaoRGS0V3Xf8+Tuu9z99vDnQeBegjuNZwGXh5tdDrww/Pks4AoP3AJ0mNlq4DnADe7e4+69wA0U7vMjIgvlHkwwo5K7WYTnKKY7o4lKvsOL9LSzgUKDM94GrDezdWbWBLwcuCaK+KIWW/Id03Glxo32VGbsWc/U7IeQmTWH18ly7Gst8ETgt8BKd98VrtoNrAx/nqkssKRyQRFZgD13wXC6ymxj4RnY8bugQ2rE4hxq8CrgZuB4M9tuZucDHzOzO83sDuCZwFvCbQ8zs+sA3H0KeCNwPUErzLfcvermSB0en2IopklvRicyKj2R6I0cSOe+E8TMTjazD5nZb8ysHxgBRs2s38x+bWYfNLMnzmO/7cC3gTe7+0HD0bi7U8ZesmnupyMSu54twbjWUpzMJOzYGDxHqCHSo+Vw91cUWPyVGbbdCZyZ8/t1wCHDEFaTXf3xTou9Z2CMpYsaY41BakwlW2qG90PX+srtP2Zm9gLg3cAGwICtwK3AgfD3TuBY4B3AhWa2EXifu19bxL4bCRLvr7v7d8LFe8xstbvvCu9Y7g2Xz1QWuAM4LW/5TYWO5+6XAJcAbNiwQb2/RYo1tC8YzUNKMzEMu/4Ah/8ZmEVyyESVnUjA3dkdc/K9u39Mo55IdCbHYHywcvsf64Op6hxG08x+ClwNDAHnA6vd/Wh3f7a7v9zdXxb+vA5YDfwjMAxcY2Y/mWPfRtAocq+7fyJn1TXA9Igl54THn17+6nDUk6cA/WF5yvXAGWa2LOxoeUa4TETKYWIkSCBlfob3BeOARyS2lm+ZWc/wBGOTmVhjmJjKsn9onBVLWmKNQ2rEyP5ojrHksMofJ3p9wBPd/Y65NnT3PcClwKVmdjLBCCSzeSrwKuBOM9sULnsn8BHgW2G54MPAS8N11xHcpdxMUPJyXnjcHjN7P0GfHQha3TUMjUg5ZLOwa1Ptzl5ZLgc2w6Jl0NZV8UMp+U6g7b2jcYcAwPa+USXfEo2hvXNvU45jVGHy7e4vmufrNhF0bJ9tm18RlK0UcnqB7R14wwz7upQg8ReRcjqwOZjNVxZu9x2w9mlQX9myW5WdJMzoRIb9CRnqr2doguHxeDp9Sg3JZqPpEDm8PxiCS0SkWoz1J2bK9KowNQ577634YZR8J8z23pFE5QeP9GhmLKmw0R7IRvAlLztZE7NdmtlyMzsxb9k6M/svM/u6mT0nrthEpMz23EMZBxsSgIEdFZ+cTcl3gkxmsmzvS0bJybRd/aOMT8Vbfy5VbmhPdR4rPp/m0QlwpocJ/CVBOcgrgGvN7OkxxSYi5TKws2bnMKi4fX+s6O6VfCfIjt5RMplkfYPNZmFbT7K+EEgVcVfyXX6ncvBQrC8DDiPoCHkYwfwI/xZDXCJSLu6Rjs5Rc8b6Kzr9vJLvhMhkPbElHtt7R5jMaHpuqYCxvqDGLiqTo7XQMWklB88m+Txgo7v/yN13A5cRzFQpImk1tDcYn1oqp4K19Eq+E2JH7ygTU8lMcKcyzraEfjGQlBuMoSU6jmNGaxJYlPP7M4Cf5/zeByyPMiARKTPNYll5oz0V+4Kj5DsBMlln64Fkf4N9pEet31IBg7tq45jRuh94cTjRzd8QzG55Y876NYDG2BZJq8xkZWcElkcNVObzQsl3AmzrGUlsq/e0qUxyy2IkpUb7YCqGmVwnR2BsIPrjRudzBK3dvcD/AVs4OPl+GnBnDHGJSDkM70cjnESkQl9yNMlOzCYz2cS3ek97pGeENctaaWrQdzYpgzhboAd3Q8uS+I5fQe5+hZk58EKgH/iQu09CMAwh0AF8PrYARWRhqr/fSnKMDwQjT9SVN+9R8h2zhw+MMJWwEU5mkskE5THHrVwcdyiSdu4xJ987ofu4+I5fYe7+P8D/FFh+APiz6CMSkbIZH4w7gtrhWZgchuby5j1qwozR2GQmdR0Zt/eOMDqhcb9lgUZ7ox3lJN/kaE1MuCMiVSiOcr1aVoHPKrV8x+ih/cNksulo9Z6WzcKD+4Y46fClcYciaTawM+4Igo40i5bFHcWCmdml83iZu/v5ZQ9GRCovOxl3BLUlU/7zreQ7JsPjU+xM2GyWxdrdP8aRy1tZ0tIYdyiSRtlsUHMdt8Gd0H1C2Wv5YnBugWXT3+qtwHILn5V8i6RS/n9rqSgr//lO/adOWm3eO4Snq9H7IA/sGYo7BEmr4X3JaLnJTMLIgbijWDB3r8t9EEyyswm4GvgLgg6WHcBTgWuA28NtRCSN6tRuGqkKnG8l3zHoHZ5g32CM9a5lUA1/g8RkYEfcETwqSbGUzyeAve7+Ine/xd0HwsfN7n42sD/cRkTSqKEl7ghqS0Nz2XdZcvJtZsvM7HgzO87M0l8wGTF354G91dFqHLTep7j5XqKXtMkhhvZAZiruKMrtTOD7s6z/friNiKRRc3vcEdQOq4PGtrLvds7k28zqzOxsM7vSzHYQtJrcA9wL7DezHWb2dTN7oZmpJX0OewbGGRhNwC33Mhgen2JHSuvWJSYDO4Ohm5LCs9U442UzcMQs648ItxGRNGrRgAeRaWqvSL+gGQtZzKweeD1wIXAYMAzcBlwHHCCo+O8EjgX+BngFsMvMPgR80d01Hl2ebNbZXCWt3tO27Btm1ZIWGur1vUuKkMQyj4Ed0LEm7ijK6VfAP5vZj9z9F7krzOwZwD+H24hIGi3qjDuC2tG6vCK7na2K/B6CFpJvEEzW8Av3wk1WYYv3acCrgI8BbwROLGukVWBb7whjk9X1nWRiKsvDPSMc063bYDKH8cFkzsw22gsTw9BU/luLMfkXguT6Z2a2EfhjuPwEYAMwALw1pthEZKEaW6B5STD7olRW+4qK7Ha25sprgaPd/Xx3v2mmxBvA3bPu/lN3Pw84BvhRuQNNu8lMlof2p2Ma+VI90jPC+FR1famQCuhPYKv3tCTHViJ3vwd4EvBNgkaQV4WPE8Nlf+bud8cXoYgs2OJVcUdQ/RqaKzYXxIwt3+7+L/PZobvvBt4y74iq1MMHhlMzjXypMhln6/4Rjl+laedlBu7JLDmZNrADutZXZDzXOLj7VuDvzMyA6aabfbM1oohIiiw5HPY/wKND+kvZLTm8Yp8JKtSNQDCNfHV3TNzRp2nnZRbD+yAzEXcUM5saq4oxv/N5YE/4UOItUi0aWypWEiGhpZXrC1T0yOFmlgV2A2e5+20F1v89cIW715cxvqqw9UD6ppEvlaadl1n1b4s7grn1b4O2rrijKBszWw+sB5ZTYEo8d78i8qBEpHyWrQ2GS5Xya18JTa0V232p0/YsB24ys3Pc/f8qEVC1GZvMpHYa+VLtGRhjXVcbbc2afUtyTI3DUILG9p7J0F6YmoCGprgjWRAzWwlcDjx7elGBzRxQ8i2SZq2dQU3yaG/ckVSfzqMruvtSs6R/BV4CfMPM3uPuH6pATFXlof3DZGvkZq978Peq9VsOMrCDVNQlehYGdwatSen2WYLE+wvATwmGhhWRatR1HGz7bdxRVJe2FbCoo6KHKDX53g+cDlwKfCC8rfmP7l51U8SVw9hkhl39tdHqPW13v1q/JU9fCkpOpvVtq4bk+9kEcy28Me5ARKTCWjuhtQtG9scdSfXoWl/xQ5Tc4dLdJ939VcB7gXOAGzTNfGEPHxipmVbvXFsPVOeQijIPIz0wORJ3FMWbGKqGW7h1wB/iDkJEItJ9PIWry6RkS4+AliUVP8y8Rztx9/cSjB37FOAW4LhyBVUNxqcy7OhLUdJRRrv7xzTyiQTS0NEyX//2uCNYqF8CT4g7CBGJSMuSIGmUhalrgOWVb/WGBQ416O5fJ7jF2Qm8qywRVYltPaM12eoNQe33tt7a/OIhOTKTMLg77ihKN7ALMqmupPsX4Gwze3HcgYhIRLqOg7rGuKNIt+XHBkM4RqCUwtzLgQfzF7r7r8zsKcCVPDqZw5zM7FLgBcBedz8pXPYfwF8DE+GxznP3vgKv3QoMAhlgyt03lPB3VFwm62yv8eRzR+8o67raaKzXUPI1a2Bn0IkxbTwDg7ugo3JjvFbYF4Ah4FtmthPYQnCtzOXufnrkkYlIZTQ0BeUne+6KO5J0al4MHUdFdriiMyN3P8/dC3apdfcH3f3J7r6uhGNfBjw3b9kNwEnu/njgfuAds7z+me5+ctISb4Bd/aNVO5tlsTJZr5khFmUGaSw5mZbm2OFooBF4BJgCjgTW5T0qO46WiERv6REVmw696q18LNRF11hY9JHMLGNmr5hl/cvMrOh7te7+C6Anb9mPc0ZOuQVIZRFTtc9mWaztvaO41/aXkJo12gfjg3FHMX9j/TA2EHcU8+Lua9193VyPuOMUkTIzg5UngemOc0k6jor8S0sp/0LG7N1p51pfqn8AfjjDOgd+bGa/M7MLZtuJmV1gZhvNbOO+fZWf6KN3eILh8VTXi5bN6ESG/UMJnlJcKifdLceBavgbRKS2NLcHtctSnIaWoF4+6sOWcV9HEtRhL5iZ/TvB7dKvz7DJX7r7DjNbQTDU4R/DlvRDuPslwCUAGzZsqHgz7A6VWhxkZ98o3Yub4w5DopSZDDotpt3ATug+Aerq445kXsxsCfAsHi0x2QLc4O4pviUhInNati7o7D6ezrt3kVr1OKiPfl6SWY9oZmcBZ+UsusDMnlVg006Ci/yvFhqQmZ1L0BHzdJ+hZsHdd4TPe83su8ApQMHkO0qTmSx7B8fiDiNR9g+NMzaZoaUxnQmMzMPAzqDTYtplp4K/JYUdL83sNcDHgXYevSPpwJCZ/Yu7fyW24ESksurqgqTykZvT2ek9KkvXQFtXLIeeK90/GTg3/NmBp4ePfEPAb4AFzahmZs8F/g14hrsXHC7EzNqAOncfDH8+A3jfQo5bLrv7x2p2eMGZuAfnZW1XW9yhSFSqqVyjf1vqkm8z+xuCu31bgHcDd4erHgv8M3CJme119+/HFKKIVFrLkqD8ZP/9cUeSTA0twZ3NmMxa8+3u73X3OnevI2g9eeX073mPJe5+hrtvLvbAZnYVcDNwvJltN7Pzgc8CiwlKSTaZ2RfDbQ8zs+vCl64EfmVmfwBuBa519x+V/JdXwK5+tXoXovNSQ9Le0TJfOjte/htwL3Cyu3/G3W8MH58BngT8EXh7rBGKSOV1Hg0tS+OOIplWPT6WcpNpRR3ZzJqB84A7y3Vgdy80ckrBW6HuvhM4M/x5CwmcvW1kYoqB0cm4w0ik4fEpBsYmWdKiCQCqXjW1ek/r3wYtj407ilI8AXifuw/lrwjvGF5O0CIuItXMLEgyH/61yk9ydRwFbctjDaHY0U4ywH8Dz6xgLKm2W627s9o7oPNT9aqlo2W+gZ1pm/FyrlGnNP6nSK1obo9lNI/EamwNJiOKWVHJdzj29m7KO5RgVdkzMB53CIm2u1/np+pVS0fLfNmpYMbL9PgDcG7YJ+YgZtZO0I/nD1EHJSIxWbYWFnXGHUUCGKx+fCJGsCplnO//BV5qptHb8w2PT2ls7zmMTWboV1lOdavGkpNp6frb/gM4EbjdzN5gZs8MH28EfgecEG4jIrXALBj9pC6+GudE6Dw6MTOAlvIvMV12coOZfQp4ADhkRBJ3f6Q8oaXH3kG16hZj3+AYSxep7rsqjfZWV0fLfGP9wSMFnZfc/Xthov1R4L94tMzEgGHgje5+dVzxiUgMmsJyiz13z71tNWpK1uRDpSTfdxFcxA04bZbt4m/Pj9g+Jd9F2Ts4zrErFscdhlRCX6pahuenbxusSn7yDeDunzezK4FnA9NTyU9PstMfX2QiEpuOI2FwD4zsjzuSiE2XmySncKOU5Pt9qKPOIcYmMxrlpEgj4xlGJqZobarxW1/VJjOZtpro+RncFYwLG+PwVKVw9z6CckERkcCqk2Drr4K+LLUigUMuFv0p4u4XVzCO1No/pFbvUuwbHOeo5elIXqRIAztqYxir7BQM7gxajxLMzJ4I/IW7f26G9W8Afu3umyINTETi17goGP1k7z1xRxKNprZElZtMS04bfErtH5qIO4RU0fmqQrVQcjItHX/rRcDzZ1n/POA9EcUiIknTcWRiOh5W3KrHJarcZFpJEZnZYjN7j5n9ysweMLNTw+Vd4fL45uqMQTbr9A4rmSxF38gEk5kaaCWtFSM9MHHIXC7Va3wgmMUz2f4c+Pks638OnBJRLCKSNGaw8iSo9sHrEvwlo+gzb2bdwEaCmdGWA0cDiwDcfT9wDnBBBWJMrN6RCTJZlcGXwh19Yakm6RqCrzyS/zd3AT2zrO8LtxGRWtXcHtRCV6uG5kRPLlTK154PAKuAJwNP49AJd64GTi9TXKmgEor52ac6+eqQmYTB3XFHEb2BXUmf8XIv8NhZ1p/E7Mm5iNSCzmOCGR+rUfeJUJ/coY1LSb5fAHze3W+n8KgnW4A1ZYkqJQ4oiZyXHrV8V4da6WiZzzNBx8vk+gnwGjM7JAE3s8cA54fbiEgtq6uDFY+JO4rya+2CJavjjmJWpSTfXcDmWdZngZaFhZMeIxNTjExU4VTaERifzDI4puEZUy8dnQ8rI9l/+weADHCbmX3WzF4TPj5LUDo4Bbw/1ghFJBnau6F9RdxRlJHBihPjDmJOpYz5ths4Zpb1TwRqZnbLAyo5WZD9QxMsbknuLSGZw2hvbXW0zDc+kNgZL939QTM7HbgM+Ke81XcD57n7A5EHJiLJ1H0CDO+vjjuZy44K6tkTrpSW7+uA883skLZ8M3sy8GqCuu+aoPG9F0YlOynXvz3uCOKX4HPg7hvd/STgScDLwscT3f1x7r6xlH2Z2aVmttfM7spZdrGZ7TCzTeHjzJx17zCzzWZ2n5k9J2f5c8Nlm83swoX/lSJSFk1tsGxt3FEsXH1jIsf0LqSU5Pu9BLcrfw98mKDu+xwzuwr4BbAT+GjZI0ygTNbpHVHL90L0j05qyMG0ykwFnQ5r3cBOyCa79MzdN7n7/4aPP8xzN5cBzy2w/JPufnL4uA7+VFP+coIOn88FPm9m9WZWD3yOYIzxxwCvCLcVkSToPAbqm+KOYmGWr090J8tcRSff7r4beArwW+AfCEY7eRXwUuDHwNPcvSZ60PeOTJBV3rgg7up4mVqDu4JOh7UuO5Xo0V7M7Olm9gEz+/L0HAxm1h4u7yh2P+7+C4ofHeUs4BvuPu7uDxH0EzolfGx29y3uPgF8I9xWRJKgviE1rcYFNbUlfvbhXCWNsO7u29z9LKCTYMjBpwDd7v7X7p7ce7Blpnrv8lDpTkoluNwicgk8F2FL8zeBnwHvJGgsOSxcPQV8j0NrwefjjWZ2R1iWMj2TxeFAbm/U7eGymZaLSFJ0HBkksWnUdXwweVBKzGt6I3cfcPfb3P3WWmntzqV65fLQl5gUGh+Csb64o0iO0R6YGI47inxvB14M/AtwIjlzMrj7GPBd4MzCLy3aFwg64J8M7AI+vsD9/YmZXWBmG81s4759+8q1WxGZi1mQxKbNok5YvDLuKEpSymgnAJhZK7CWYJbLQ75mhLcoq5aGGCyfiaksA2OTLNGoJ+kxsCPuCJJnYCd0rY87ilyvBq5w90+b2fIC6+9lgcm3u++Z/tnMvgz8IPx1BwfP93BEuIxZlufv+xLgEoANGzZoCmGRKC1eGUzJPtobdyTF607uTJYzKTr5DpPuTwDnzfA6I+iEWV+e0JJp/6Baa8vpwNCEku+0cFfyXUj/9qBWMjm3PNcye0t0H7BslvVzMrPV7j7d6/ZsYHoklGuAK83sEwSlLuuBWwk+H9ab2TqCpPvlwN8tJAYRqZCu42Dbb+OOojjt4ZeFlCml5fvTBDOjXQf8FDhQkYgSbv+wSk7K6cDQOOu6UlpjVmtGDsCU3v+HmBqDkR5oK9TIHItBgn45MzkWKLqeIxzR6jSgy8y2AxcBp5nZyQQNLluB1wK4+91m9i3gHoL68je4B71zzeyNwPUEDTSXuvvdJf1VIhKN1s5g4p2hvXFHMgcLviikUCnJ99nAVe7+95UKJukyWadPQwyW1fSQg4318+p+IFFKYOfCxBjcmaTk+1fAK83sY/krwo6R/wD8qNidufsrCiz+yizbfxD4YIHl1xE03ohI0nUdD0P7CL5fJ9TSI1IxoU4hpWQ8LcBNFYojFXqGNcRguWnIwZTITKWgFSRGg7uTNOb3BwnKPX4KvCBc9gQzey1wO9AGfCSm2EQkDZrbg+Q2qaw+aX1tSlJK8r2R4IJes5QkVoaGHEyB4b0a23s22eR8OQlnsHwxcALw1XDxfxKMULIIONvd74kpPBFJi671QZKbRJ1HQ0Nz3FHMWyllJxcC3zezb5U6PXG10BCDlaEvNSmgGS3nNrgLlqyOOwoA3P1aM1sLPJtHhxt8ALje3UfijE1EUqKhOUhyDzwQdyQHa2iGznVxR7EgMybfZnZpgcXbgVvM7GZgC5DfFObufn4Z40uM0YmMhhiskPHJLEPjU7Q3lzzypUQhMwkj++OOIvmG9wXlOfXJeB+7+zjBEIA/mGtbEZGCOtdB/yPJ6mzfdRzUJbRFvkizfUqcO8u6p4aPfE4wIkrV6VFHy4rqGZpQ8p1UQ3vA1dlhTp4NynOWHDb3thVkZvVAc24Ldzid/PkEo6B8w93vjCk8EUmTuvqg8+XuO+KOJNC8BJakf3LcGWu+3b1uHo90fxWZRa9KIypKX24SbHDP3NtIYHB33BEAfIlgbG0AzKwR+DXwH8A7gFvDYQJFROa25DBo6Yg7isCKE5M0p8K8aXy3IqkuubJ6RyZwT/CQRrUqM6WSk1IM70/CqCd/STDZzbSXENR9vwH4C2APQR8eEZG5mQVJb9wWrw7GIK8CSr6LMDIxxcSUbrtXUibjDI1PxR2G5Bvep5KTUngmSMDjtRp4KOf35wN3u/sX3P0WgqnbT40lMhFJp0Ud8ZZ7WD10nxDf8ctsxuTbzP7HzI4udYdmtt7MvrawsJKlb2Qy7hBqgs5zAg0nY/i8VIn/nBnBLJLTTgN+lvP7LmBFlAGJSBXoPh7qGuM59vJjoLElnmNXwGwt38cC95rZ/5nZ35jZopk2NLN2M3uJmV0N3A0UNQaMmV1qZnvN7K6cZZ1mdoOZPRA+L5vhteeE2zxgZucUc7z5GhhTUhgFneeEcQ9avqU08Z+zh4DnAJjZUwlawnOT78OA/hjiEpE0a2iGrmOjP25jKyxL99CC+WbrcHkqcB7wWOB7QL+Z/T5Mxi8xsy+b2bfN7A6gF/gWcAzwKncvNBJKIZcBz81bdiFwo7uvB26kQG2imXUCFwFPBk4BLpopSS+HwTGVQ0RhYFTnOVHG+oNhBqU0U+MwNhBnBF8FzgobNX4A7AWuz1n/ZOCPcQQmIinXcRQ0L472mCsfC3XVVSU969hu7n4lcKWZnQ78LfB04IU8mrRngXuBLwL/6+6/KOXg7v6LcCKIXGcR3CYFuJxgSvu3523zHOAGd+8BMLMbCJL4q2Y73n333cdpp5120LKXvvSl/NM//RMjIyOceeaZh7zm3HPP5ainnEl/7wHe95bXHLL+r192Dqc974Xs3bWDj77jjYesf8k5r+fUZ57Btoc286n3/ush6//+tW/hSac+nc333sUXPvruQ9b/w5veyWOf+Ofc/fvbuPTTHzpk/evf/n6OPfEkbr/5F3z9S5/80/JtPcEoY9uO+xxr1h3LzT/7Mf93+RcOef3bP/xZVqw+nJt++D2+/83LD1n/nk/+N0uXLef6736DH1/9zUPWf/ALX6dlUSvXXPVVfn79NYes//hl3wXgf7/6eW75+Q0HrWtubuFDXwr+yb72hU/w+9/+kmWtTX9av3z5cr797W8D8I53vIObb775oNcfccQRfO1rQYXTm9/8ZjZt2nTQ+uOOO45LLrkEgAsuuID777//oPUnn3wyn/rUpwB45Stfyfbt2w9af+qpp/LhD38YgBe/+MUcOHDgoPWnn34673538G/2vOc9j9HR0YPWv+AFL+Btb3sbwCHvOyjuvXfuueeyf/9+XvKSlxyy/vWvfz0ve9nL2LZtG6961asOWf/Wt76Vv/7rv+a+++7jta997SHr3/Wud/GsZz2LTZs28eY3v/mQ9R96+xv4i6Pb+c3t9/DOTx763vjUOy/g5BOP4Se/+T0f+MI3Dln/pff+M8cffQTf/+lv+fhXv3PI+v/52NtYs7qbb173c75w1XWHrP+/z7yTrmVLuew7N3DZd39y8Mq+rVz3T8fTCnz+yh/wrR/+8pDX3/Q/HwXgP7/ybX5w060HrVvU0sQPv/x+AN7/+Su58eY/HLR+ecdivv1f7wLgHR//KjdvOjhXPWJVF1/7j+D/85s/9CU23bvloPXHnfgYLrk8OCeVeO/N4dPAYoJr9e+Bd04PO2hmy4GnEMx4KSJSGrMgGX7klmiOt3gVtHVFc6wIFTWwsrvfSNAKjZnVAcsJxvQ+4OUfomKlu09Pp7cbWFlgm8OBbTm/bw+XHcLMLgAuAGhuLn0q0slMlkxWo3BEJZN16uvSP4xQVRjrB9rjjiKdYpyQIrwmvz985K87gOq9RWQhFi2DpUdA//a5t10Iq4fuBIyyUgEW9/BuYcv3D9z9pPD3PnfvyFnf6+7L8l7zNqDF3T8Q/v5uYNTdZ23N2bBhg2/cuLGk+HqGJ7j94d6SXpMEH7s+aKn7t+ekq3fw49csZcXi6ulUkVrZLGy+Ibkjndz43uD59IvijWMmVg/HPqust0rN7HfuvqFsO0yB+VyzRSQCUxPw0C8gW2Rp4nyu2d3HB9Pbp9Rs1+wkFtHsMbPVAOFzoaEDdgBrcn4/IlxWduNTsY/ZW1PGJxOa7NWasb7kJt5p4BkYj6bu28zOD+9Ilvq6ejM7tJZORGQuDU3QfVzl9t/UDh1rK7f/mCUx+b4GmB695Bzg6gLbXA+cYWbLwo6WZ3Bwh6KyUTIYrXGNp54Mo+m725M40Z3DjwN/NLM3mtmcxZFmttLM3gLcRzDrpYhI6ZauCaZ7r4QVj6m6Tpa5iqr5rhQzu4qgc2WXmW0nGMHkI8C3zOx84GHgpeG2G4DXuftr3L3HzN4P3Bbu6n3TnS/LbSqrZDBKqq9PiNG+uCNIv9Feihx1daHWAx8EPgl83Mw2Ekwv/yDQQzDud2e43VOAk8PXfQV4TxQBikgVMoOVjyl/58vFq6BteXn3mTCxJt/u/ooZVp1eYNuNwGtyfr8UuLRCof1JRrl3pPRlJyHGNQz0gkVUduLu+4ALzOy9wOsIppN/0wyb3w18APhyTsd2EZH5WbQMlhwGAzvLs78qm8lyJrEm32ngqCU2SjH3/xWAybFYR+uoGpOjQaekhqa5ty0Dd98BvBt4t5mtAB4DdBOMTLWPYIr5/ZEEIyK1o+t4GNwT9HVZqM510DjjnI5VQ8n3HOpMw95FSec7ASJqsa0J4wPQEP0Yte6+l8Kd1UVEyquxJUiaD2xe2H7qm6puJsuZVG81e5koGYyWxvhOgPHBuCOoHjqXIlILlq0LkueF6FoP9bXRJlx08m1mWTPLzPGouvnBmxv0/SRKTTrf8ZsYijuC6qFzKSK1oL4Blh8z/9c3tsKSI8oXT8KV8hXjCjikALoBOAZ4MnAHsKk8YSWHksFo6ctOAkwMxx1B9dC5FJFasfRI6Nkyvz5Dy4+t6qEF8xWdfLv7uTOtM7O/IBif+/VliClRWpvq4w6hpuh8J8DESNwRVA8l3yJSK+rqghkp995b2usaFwUjptSQsnzNcPffAF8FPlqO/SVJW1MDKvuOTltzbdR7JVZmsvjpgmVumQnIapZcEakRS9dAfWNpr+k8mlpLtMqZ6TxAFbZ819UZ7c0NDI5VXTl74rQ21dNYXzu3nRJpUq3eZTc5As2L445CRGRuX33+wvcxOQJTowcv6304eL7xvXkb18GiDoK5wBbgvGsX9vqIlTP5Pg0YnWujNFrW1qTkOwIdrdGMhyyz0Pje5Tc1HkvybWZtwKnASuAn7r4n8iBEpPY0Ljp05JNVjy+8rRkLTrxTqOjk28xePcOqTuBZwPMIpiuuOstam3jkgFoEK62zTcl37KbG4o6g+sRwTs3s9cCHgSUEHeWfDewJJ995BPhnd/9y5IGJSLKlrAU5rUpp+b6M4CJe6CvKFEHi/ZYyxJQ4y9uaqK83MhlNv1gpdXXQ1a7kO3Zq+S6/iM+pmb0Y+BxwNfB94L+n17n7XjP7EfBCQMm3iEgMSkm+n1lgmQM9wEPuXrXd+uvqjK62ZvYMqFWwUjrbmmlQvXf8MhNxR1B9oj+n/wr8zN3PNrPl5CTfoY3AP0YdlIiIBEoZavDnlQwk6VZ3tCj5rqDVS1viDkFALd+VEP05fRzw9lnW7wJWRBSLiIjkUVNjkZa3NdHcqNNVCY0NdXS3N8cdhgBk1bG47KI/pxlmv7YfBlTtnUoRkaQrabQTM2sgqBV8MrCMQy/w7u7nlye0ZDEzjljWyoN7NV10uR3e0UJdXe31dk6kjMb4Lrvoz+kfgOcAn8lfYWZ1wN8Ct0UdlIiIBEoZ7aQT+BlwEkGny9zOl56zrCqTb4Ajli1i6/5hMll1vCyXujo4Yllr3GHINE2wU37Rn9PPAleZ2fuBK8JldWZ2PPAh4LHMXpYiIiIVVEodxQeAE4DXAMcQJNvPAU4EriJoSVle7gCTpLG+jsOXLYo7jKqyaskiWho1pXxiqOyk/CI+p+7+TYIk+9+B6XmefwTcA5wNvNfdfxhpUCIi8ielJN/PB65w968CA+GyjLvf5+6vJJhg58PlDjBpjuxspU6l32VhBuu62uIOQ3Jls3FHUH1iOKfu/i5gA/Bp4IfAjwlaxE9x9/dFHpCIiPxJKTXfq3i0TnC6KSd3iIrvEQxxVXVTzOdqaazniGWtmnSnDA7rWMSiJrV6J4Y7eCbuKKpPTOfU3W8Hbo/l4CIiMqNS2nB7gOlmykFgEliTs36SoBNm1Vu7vI2GenUQXIj6OlOrd9K4Wr0rwrPBFxsRERHmaPk2syOBfe4+CtwPPAbA3bNm9nvgXDO7DKgHXg1sqWy4ydDUUMe6rjYe2KORT+bryOWtqvVOmqxavSsmm4H6kgaXWhAzOwq4AFhP0Bcnv7XA3f30yAISEZE/mevT4CHglQQdKn8MvM3M3uju48AngG8QtIg7sIjgYl8T1ixrZUfvKCMTSlhK1dxYx1GdGuEkcdTyXTkRnlsz+xvgf4FGgv45vZEdXERE5jRX8m082mLyIeA/w8Qbd/+WmU0RJOcZ4P/CXvY1oa7OWL9yMX/Y1hd3KKmzfsViTSWfRKr3rpxoz+1HgW3A2e5+Z5QHFhGRuZUyvbwD43nLvgN8p9xBpUX34maWtzdxYGgi7lBSo6O1kVWaSj6Z1PJdOdGe27XA25V4i4gkk5ofF+j4VYs19GCRzOCE1UviDkNmouS7cqI9tw8BzVEeUEREildMy/fTwmnli+LuV8y9VfVobWpg7fI2tuwbjjuUxDtqeSvtzdF1OpMSKfmunGjP7aeAt5rZ591dFyYRkYQpJhO6gOI6Uk5PL19TyTcEQw/uHhhjZFw1szNpaaxnXVd73GHIbDTBTuVEOJKMu19iZkuAu83scmArQb+c/O1q7lotIpIExSTflwC3VDqQNKurM05ctYTfPaxBBWZy/KrF1NdpbPREU8t35UQ4zreZrQReBBwJvHumiKjBhhIRkSQoJvn+pbtfWfFIUm5ZWxOrO1rY1TcWdyiJs2JJM92LVYKaeBrtpHKiPbdfBP4c+CTwSzTUoIhIoqgAt4zWr1jM/qEJJqfUgjitvt44buXiuMOQYmiSncqJ9tyeDnza3d8W5UFFRKQ4GqejjJoa6jhupeqacx3b3a6ZLNNCZSeVE+25HQc2R3lAEREpnpLvMlu9dBHL2hrjDiMRlixq5Ihli+IOQ4qVnYo7guoV7bm9Fnh2lAcUEZHizZp8u3td1PXeZna8mW3KeQyY2ZvztjnNzPpztnlPlDHO5YRVS2p+7O9gTO/FmKmTZWqo7KRyok2+/wVYY2afMbNjTP8JRUQSJXE13+5+H3AygJnVAzuA7xbY9Jfu/oIIQytaW3MDR3a2snX/SNyhxOaIZa0sadEdgFRRy3flRPvFZj/BaCZ/BrwBKPQl2N09cdd/EZFakPSL7+nAg+7+cNyBlGpdVzu7+8cZm6y91sTGhjqO7m6LOwwplZLvyon23F5BkHyXhZldCrwA2OvuJ4XLOoFvEkxlvxV4qbv3hq3snwbOBEaAc9399vA15wDvCnf7AXe/vFwxioikSdKT75cDV82w7lQz+wOwE3ibu98dXVhzq68z1q9s587t/XGHErljV7TTWF/jdTdplJ2MO4LqFeG5dfdzy7zLy4DPcvC44BcCN7r7R8zswvD3twPPA9aHjycDXwCeHCbrFwEbCL4Y/M7MrnF3DYMoIjUnsRmSmTUBfwP8b4HVtwNHufsTgP8CvjfLfi4ws41mtnHfvn0ViXUmK5e01Fzny8UtDRy2tCXuMGQ+Mmr5rpgU31Vw918APXmLzwKmW64vB16Ys/wKD9wCdJjZauA5wA3u3hMm3DcAz6148CIiCZTY5JugBeV2d9+Tv8LdB9x9KPz5OqDRzLoK7cTdL3H3De6+obu7u7IRF1BrY1wfv0qdLFNLLd+Vk6m6c7vS3XeFP+8GVoY/Hw5sy9lue7hspuWHiLPBREQkCklOvl/BDCUnZrZquge/mZ1C8HcciDC2oi1uaWR1R220BK9Y0kxHa1PcYch8ZSbijqB6VfDcmlnWzKbCu4XTv2fmeJStKd7dnTLWmMfdYCIiUmmJrPk2szaCcWpfm7PsdQDu/kXgJcDrww+QUeDl4QdAIh3T3c7egXEy2cSGuGBmQa23pFj1tc4mR2W/2Ex3sMzk/V5Je8xstbvvCstK9obLdwBrcrY7Ily2Azgtb/lNFY5RRCSREpl8u/swsDxv2Rdzfv4sQQegVGhprGdN56KqHnrw8GWLaG1K5NtJipHNpLouOfEyk5DNUokJANz9XDM7EmgCRivQ4bKQa4BzgI+Ez1fnLH+jmX2DoMNlf5igXw98yMyWhdudAbwjgjhFRBInyWUnVeXIzjbq66uzFrquDtYu19CCqTY1HncE1a+yrd8PAWdXYsdmdhVwM3C8mW03s/MJku5nm9kDwLPC3wGuA7YQTG//ZeCfANy9B3g/cFv4eF+4TESk5qipMiJNDXUc2dnKQ/uG4w6l7I5Y1kpLY33cYchCZJR8V1xmHBor1v+jYt/s3f0VM6w6vcC2TjixT4F1lwKXljE0EZFUUst3hI7sbK261u+6OjhqeWvcYchCqeW78nSORUQEJd+RaqyvY82y6kpUD+9opblBrd6pNzUWdwTVT+dYRERQ2Unk1nQu4pGeYbLZuCNZODO1elcNtcpWXuXP8dPMrOhrurtfMfdWIiJSbkq+I9bcUM/qpYvY0TsadygLtnJJi2q9q8Vk+t+PiVf5lu8LwsdcjGAoQiXfIiIxUPIdgyM7W6si+T5Srd7VQy3flTdZ8eT7EuCWSh9EREQWRsl3DNqaG1je3sSBofTOKLisrZElLY1xhyHlMpX+L4OJV/lz/Et3v7LSBxERkYVRh8uYHNmZ7lbjaus4WtPc1fIdhcq3fIuISAoo+Y5JZ1sTrU3prJdubqyjq7057jCkXKbGwaugB3DSeSaY6VJERGqaku+YmBmHL1sUdxjzcljHIurqqmu88pqmIfCio46tIiI1TzXfMVq9dBEP7htK3bCDh3ek80uDzEDJd3SmxoAlZd+tu6shRUQkJXTBjlFTQx3d7RWbbroilrc3aXjBaqPkOzo61yIiNU/Jd8xWd6Qr+VardxVSZ8vo6FyLiNQ8Jd8xW97WRHNjOv4ZGupNHS2rkVpjo6NzLSJS89KR9VUxM2P10nS0fq9a2qKOltVoKr3jzaeOzrWISM1T8p0Aq5amo5RjdUrilBJlVAoRGZ1rEZGap9FOEqC9uYHFLQ0Mjk3FHcqMWpvqWbpIM1pWpYxaYyOjc516L/vSzXGHMC/ffO2pcYcgIiG1fCdE0luVV6ujZfXKJPdLX9XRuZYCsu7ctaOfu3f2xx2KiERALd8JsXJpMw/sHcQ97kgKW7UkHXXpUqJsNph5UaKRVfKddpVoQe4bmeClX7qZhro6tVCL1AC1fCdEc0M9y9qa4g6joI7WRhY1aWzvqqTEO2IOWZ1zOVhDffBRbOrPLlITlHwnSFJHPVmpVu/q5SmbXrUa6JxLnqYw+a5T9i1SE5R8J0h3ezP1CRvKz0zJd1VTIhg9nXPJ09RQhwEJu/yLSIUo+U6Qhvo6uhcnaxKb5e3NNDXobSJSNknt2CGxqjNTy7dIjVBWlTBJa2VWR8tqpw/7yNWp/4Qcqq7O1PItUiOUfCfM8rYmGuqTcQWur7PEtcRLmZkuAdFLxv9vSRYjmPFYRKqfPnkTpq7OEtP63b04eTXoUmZ1Gm00cmr5lkIMfS8TqRFKvhMoKaOerEpIHFJBdXVKwKNU36jx5EREapyS7wRauqiRlsZ4W8eaGupYntBxx6XM6hvjjqB21Ov/lMzAw4eIVD0l3wlkZrG3Oq9c0qL6w1rRoDsckdG5lhlkPZhmXkSqn5LvhIo7+dYoJzWksTXuCGqHzrXMIOtOVrm3SE1Q8p1Q7c0NtLfEU4vb2lTP0laVItSMpra4I6gdOtdSgLvj7mr5FqkRiU2+zWyrmd1pZpvMbGOB9WZmnzGzzWZ2h5k9KY44Kymu1ueV6mhZW5oXxx1B7dC5lgLGJrM4KjsRqRVJH+bgme6+f4Z1zwPWh48nA18In6vGqqUtbN47FP1xVXJSW1o64o6gdrQsjTsCSaCxyQwA2WzMgYhIJBLb8l2Es4ArPHAL0GFmq+MOqpxaGutZ1hZt+cfilgbampP+nUzKqqEJGhfFHUX1a2rTyDJS0PhUkHWr5VukNiQ5+Xbgx2b2OzO7oMD6w4FtOb9vD5dVlagn3Im7o6fEpHV53BFUv0WdcUcgCTURJt/KvUVqQ5KT77909ycRlJe8wcyePp+dmNkFZrbRzDbu27evvBFGYMXilkjn5EjK7JoSsbbuuCOofu0r4o5AEmoiEybfOBkNeSJS9RKbfLv7jvB5L/Bd4JS8TXYAa3J+PyJclr+fS9x9g7tv6O5OX4LR1FBHZ0ST3Sxri39yH4lJaxea27qCrE53F2RG0y3f+T+LSHVKZPJtZm1mtnj6Z+AM4K68za4BXh2OevIUoN/dd0UcaiSiKgVZsVit3jWrvgHauuKOonq1dUGdvthKYeNTmYI/i0h1SmrPupXAd8MZFhuAK939R2b2OgB3/yJwHXAmsBkYAc6LKdaK625vpq6usj3hzWDFkubKHUCSb8nhMJy+0qxUWHJE3BFIgo1MPJpwD09k6NBcTCJVLZHJt7tvAZ5QYPkXc3524A1RxhWXhvo6lrc1s29wvGLH6GhtorlBLXM1rX0F1DVAdiruSKpLXaNq6mVGE1NZRnOS74HRSQ7v0OhDItUskWUncqhKd4RcqVZvqasPWr+lvJYeAXW61EphvSMTB/3eMzwxw5YiUi30iZASXe1NFfv8NoPuxUq+BVh2VNwRVBnTOZVZ7e4fO+j30YkM/aOTMUUjIlFQ8p0SDfV1dLZVJkHuaG1UyYkEmto0JF45LV6pCYxkRmOTGfYPHVpOuL13JIZoRCQqSr5TpFKt093tGuVEcnQeE3cE1aPz6LgjkATbemC44MQ6u/vHDqoDF5HqouQ7Rbrbmysy4Y5GOZGDLOqANrV+L1j7SmhZGncUklDD41Ps6B0tuM4dHtw3FHFEIhIVJd8p0tRQx9JFjWXdZ3tLgybWkUN1rY87gvTTOZRZ3LdncNbp5Hf3j9GrzpciVUnJd8p0tZe3lVodLaWgliWw5LC4o0ivpUdA8+K4o5CE2tk3Ss/Q3In1vbsGmMpoxkuRaqPkO2W6ypwslzuZlyrSdTyY7oqUrK4Buo6LOwpJqJGJKe7bM1jkthnu36PyE5Fqo+Q7Zdqby1cm0thQx5KWRM6zJEnQ2ALL1fmyZMuPgQZ9qZVDZbLOHdv7yWRmqTfJs7NvlJ19hWvDRSSdlHynUNfiprLsZ3lbE1aJHpxSPZatC4YflOI0tUPH2rijkIS6d9cAQ2OlzyD7x90DGvtbpIoo+U6hzrbyJN8qOZE51dXBypPijiI9Vp2k2SyloIf2Dx8yoU6xslm4Y3sfY5MaflCkGuhTIoU6W5vKMuTgsrbyjpwiVaq1E5auiTuK5Os4ChYtizsKSaA9A2M8uHdhtdvjk1k2betTB0yRKqDkO4Ua6hc+5GB7S4NmtZTidR8PDZqMaUaNi9TJUgrqG5ng7p39ZdnX0NgUd+7oJ5stvmZcRJJHyXdKLVtg6Um5SlekRtQ3wqrHxx1Fcq16PNTXXudlM9tqZnea2SYz2xgu6zSzG8zsgfB5WbjczOwzZrbZzO4wsyfFG33lDY1PsWlbH9kyNlYfGJrg3t0D5duhiEROyXdKLWtdWPK80NdLDWpbHpRWyMGWrQtKc2rXM939ZHffEP5+IXCju68Hbgx/B3gesD58XAB8IfJIIzQyMcXvH+llqoSRTYq1q2+M+4scrlBEkkfJd0otXdS4oH5dHa2q95Z56D4+GNFDAs2LVW5yqLOAy8OfLwdemLP8Cg/cAnSY2eoY4qu4ofEpfvdwL+OTlavPfuTACH/cPYDPNk2miCSSku+Uqq8zlrTML4Fe3NJAY73+6WUe6uph9RPA9P7BwnNR26ObOPBjM/udmV0QLlvp7rvCn3cDK8OfDwe25bx2e7jsIGZ2gZltNLON+/btq1TcFdMzPMHGrT0VTbynbe8Z5c4d/WRUAy6SKjX9qZF2HfMsHZnv60SAYOr57uPjjiJ+K07QFPLwl+7+JIKSkjeY2dNzV3rQLFtSZujul7j7Bnff0N3dXcZQK8vd2bp/uGKlJjPZOzDOrQ/1MDRe+vjhIhIPJd8pNt/SEZWcyIItWwttK+KOIj7tK6HjyLijiJ277wif9wLfBU4B9kyXk4TPe8PNdwC5Y1YeES5LvZGJKW5/pJfNe4eIowpkeHyKWx86wCMHRlSGIpICSr5TbL7DDS50mEIRAFY/vjaHH2xcBKseF3cUsTOzNjNbPP0zcAZwF3ANcE642TnA1eHP1wCvDkc9eQrQn1OekkrZrPPQ/mFu2XKA3uF4Z6DMZuH+PYPctrWXgTHNhimSZLU3NlYVaayvo7W5npHx4mc9a26so6VR43tLGdQ3BjXP226lxMqC9LI6WH1y8LfLSuC7Fsz41QBc6e4/MrPbgG+Z2fnAw8BLw+2vA84ENgMjwHnRh1w+ewfH2LxniJGJZM06OTA6ya1bejisYxHHrGjTfA4iCaTkO+WWLmosKflWq7eUVWsndB8H++6LO5JodB0HizrijiIR3H0L8IQCyw8ApxdY7sAbIgitogbGJnlgz2DsLd1z2dk3yp7BMdYub+PIzlbq68owLbKIlIWS75Rb0tLILsaK3l7Jt5TdsnUw0gvDe+feNs3aV0LnurijkJiMTWbYvHeI3f3FX2/jlsk4D+4dYnvvCMd0t7N6aQvhnQoRiZFqvlNuaYmdJ+c7PKHIjMyqv/67sVV13jVqMpPlgT2D/ObB/alKvHONT2a5Z+cAv32ohwND43GHI1Lz1PKdcu1NDdTVUfT0xYtb9E8uFVDfCIc9Ebb9Frzy4xtHyurgsJNV511jsllnR98oW/YPMzlVHe/pobEpfv9IH53tTRy3cjHtzfo8EImD/uelXF2d0d7cyMDo3PWHrc31NGhyHamURR3B+N977407kvJacSK0LI07ColQUjtTlkvP0AS/HT7AYR2LOLpbnTJFoqbkuwosbmkoKvlWyYlU3LK1MNoLg7vjjqQ8Fq/WeN41pH90ks17k9+ZshzcYUfvKLv7xzhqeStHdraqcUYkIkq+q0CxpSQqOZFIrHwcjA3A5EjckSxMUxusPCnuKCQCw+NTPLhviL0DtVcPnck6W/YNs713lHVdbRzesYg6jYwiUlHKxqrA4ubiWrQXq+VbolDfENRIP3JLeuu/rT6oYa/XJbKajU1m2LJvmF39o7HMTJkkE1NZ7ts9yCM9Ixzd3caqJRoZRaRS9MkSo5d96eay7atvZOKgaU629QStjh+7/o9/WtaxqIlyXUu/+dpTy7MjqU4tS6H7BNh7T9yRzM+KE6F5cdxRSIWMTWZ4aH+QdBfbWb1WjE5kuHvHAA/tH+bornZWLmlWEi5SZkq+q0Rbc8NBLTcnrFpy8AZG2RJvkaIsOwpGDsDQnrgjKc3i1dCxJu4opALGJjNsPTDMzj4l3XMZGc9w145+HtrfwNHdbaxYrCRcpFyUfMdIrcdS9VY9Drb2w1RKxkdubFWddxWazGTZun+Ybb0jSrpLNDw+xZ3b+2lvaeDYFe10tTfHHZJI6in5FpHKqW+E1U+AbbcCSS+qtSBW1XlXDXdne+8oD+4bYiqT9Pdfsg2NTbHpkT6WtTVx/CqNES6yEIkbV8jM1pjZz8zsHjO728zeVGCb08ys38w2hY/3xBGriBShtROWHxt3FHPrWh+MVS5VYXh8itu29nLf7kEl3mXUOzzBb7cc4KH9w3it91IVmackfnWdAt7q7reb2WLgd2Z2g7vn99z6pbu/IIb4RKRUy4+Bkf3BGOBJtKgTOo+OOwopk97hCTZt7yOjpLsi3OHBvUMMjE7yuMOXamhCkRIlruXb3Xe5++3hz4PAvcDh8UYlIgtiBqseD3UJ/L5f1wirH68eyVViYirLH5R4R2Lf4Dhb9g/FHYZI6iQu+c5lZmuBJwK/LbD6VDP7g5n90MweO8s+LjCzjWa2cd++fZUKVUTm0tQaDD+YNCtOhMZFcUchZdI3OqEykwjtG5yIOwSR1Els8m1m7cC3gTe7+0De6tuBo9z9CcB/Ad+baT/ufom7b3D3Dd3d3RWLV0SK0LEGWrvijuJR7StgqW6sVZMlLY3U1+suRlSWtzfFHYJI6iQy+TazRoLE++vu/p389e4+4O5D4c/XAY1mlqBPdBGZ0arHBaUecatr1LCCVailsZ4nrumgsSGRH29VZdXSFo7tbo87DJHUSdzVyYJR/L8C3Ovun5hhm1XhdpjZKQR/x4HoohSReWtsge7j444iKDdp0JjF1aijtYlTj17Oms5W6hL3KZd+bc0NPH7NUk5SZ0uReUlg7yeeCrwKuNPMNoXL3gkcCeDuXwReArzezKaAUeDlrjGPRNJj6REwsBNGe+I5fmuXyk2qXFNDHcevWszarlZ29o2xs2+U0YlM3GGllhl0tTdz+LJFLG9r0myXIguQuOTb3X8FzPq/2t0/C3w2mohEpOzMYOVj4eFfg0c85aDVwcrHRHtMiU1zQz3rutpY19VG/8gkewbH2Dc4rkS8CHV1wV2EFYubWbG4hSaV8oiUReKSbxGpEc3tsGwd9DwY7XGXHwtNbdEeUxJhaWsjS1sbOW7lYgbHJjkwNMGB4Qn6Ryc07XyoubGO5W3NLG9vYnlbEw31SrhFyk3Jt4jEZ/kxMLADpsaiOV7joiDhl5q3uKWRxS2NrO1qI5N1+kYm6BkOHkPjU9RKIWNjQx3LWhtZ1tpEZ1sTbZo2XqTi9L9MROJTVx+M/b1rUzTH6z4R9cCTfPV1xvL2Zpa3Bx1wJzNZ+kYm6RuZoHdkksGxyapJxnOT7Y7WRtqbG1S/LRIxJd8iEq8lq6Hv4cpPPd+6HBavrOwxpCo01tfRvbiZ7sVBMj6VydI3+mgyPjCanmS8qaHuT4n2srYm2tWyLRI7/S8Ukfh1Hw+P3FL5Y4jMQ0N9HV3tzXS1H5qMHxiaYHBsKuYIH9VQb3S2NamMRCTB9L9SRCrnq88vftuJIcgUOVV178PB843vK277+iZoKmEykPOuLX5bqSkv+9LNhyxzh6lslslMlsmMM5+Rb7f1jADwH9f/seTX1tfV0VhvNNbXUT/DuNvffO2pJe9XRCpDybeIJEMpyfGizsrFIVIis6BUpXEBI4N0tGqadpFaoeRbRCpHLchSZdSCLCILpW7/IiIiIiIRUfItIiIiIhIRJd8iIiIiIhFR8i0iIiIiEhEl3yIiIiIiEVHyLSIiIiISESXfIiIiIiIRUfItIiIiIhIRJd8iIiIiIhFR8i0iIiIiEhEl3yIiIiIiEVHyLSIiIiISESXfIiIiIiIRMXePO4bImNk+4OG444hQF7A/7iBEKqTW3t9HuXt33EFESddskapSa+/vGa/ZNZV81xoz2+juG+KOQ6QS9P6WaqP3tFQzvb8fpbITEREREZGIKPkWEREREYmIku/qdkncAYhUkN7fUm30npZqpvd3SDXfIiIiIiIRUcu3iIiIiEhElHwXycxONbNvmNl2M5swswEzu83M3m9mq4vcx7lm5ma2do7t1obbnVvEPl9oZr8ws71mNmpmD5vZ98zsucX9ZdEys4vDv60h7lgkPmZ2mZltX+A+pv+fzPW4qUxhS8roul0eum6Lrtnlpf9IRTCztwL/AfwMeBewBWgH/gK4ANgAPK+IXV0LnArsKlNc/w/4NHBpGN8wcAzwfOCvgB+V4zgiCbWL4P9TrpuBy4Av5SwbiCogSQ5dt0USR9fskJLvOZjZMwkukJ9297fkrb7OzD4M/O0c+2gEptx9H7CvjOG9Dfieu5+fs+ynwJfNLNK7GmbW7O7jUR5Talv4frsld5mZAexw91sKvkhqgq7bxdF1W6Kka/ajVHYyt7cTzMj09kIr3X3Y3S+b/j3ntso/mdnHzGwnMA50FLp9aWatZvZ5MztgZkNmdg1wRJGxdQK7Z4grm/u7ma0zs6+b2T4zGzezTWZ2dt42x5rZ/5jZQ+Gt0C1m9gUzW5a33WXhbdxTzew3ZjYKfCxc1x3+PdvC42wL99mcF+I6M7s2/JsfNrP3RP3BI+VX7HsoZ/u/CMsAxsxsq5n9c4Ft1oX73B2+p7aY2aeLjKfbzL5kZveb2Uj4frzSzA7P2+4yM9ta4PU31cIt0Cqk67au21IEXbPjoZbvWVhQ3/YM4DvuPlHiy/8duI3g9mY9MDbDdl8CXga8N9z+2cCVRR7jVuAcM9sCXO3u9xfayMzWAL8F9gJvIWjFeRnwbTN7obtfE256GLANeDPQCxwNvBO4jkNvFS0FvgH8Z7jNaPif9TcEHy4fAO4AVgBnAU0EH2bTvgt8Ffgk8Nfh378tXCbpVcp7aAnwTeCjwGbg5cBnzGxwOjEys3UE7/MR4D3AA8CRwBlFxtNJ8H/vHQTv+8OAtwK/NrMT3H2m/5eSUrpu67otJdE1Ow7urscMD2Al4MCHC6xryH3kLF8bvuZ2wqEcc9adG65bG/5+PJABLszb7gvhdufOEd9xBBdKDx/7gauAM/K2+wrBm3h53vIbgE2z7L8B+Mtw30/MWX5ZuOysvO3fF/49T5xlnxeHrz0vb/mdwI/j/jfXo7yPIt5DL8/b/gbg4en/O8AVwBBwWJHHc+ADs6yvB9aE252dF8/WAtvfBNwU93nUo6T3nK7bum7rMc+HrtnRPHS7aB7MbBUwmfuwQ3uBf8/Dd8IsnkxQ+vOtvOXfKCYOD1pMnkjQyvNBYBNwNnC9mb0rZ9PnEnyL7TezhukHcD3wBDNbEv5dTWb2TjP7Y3hLchL4ZbiP4/MOPwn8IG/ZGcBt7v77IsK/Nu/3uwi+HUuKlfgeygDfzlv2DYL3wfQtxjOAH7j7zgXE9Hoz+4OZDQFTwCMzxCNVTNdtQNdtyaNrdjyUfM/uAMHtj/yLy37gz8PHl2d4bTE946eHutqTtzz/9xm5e8bdf+Hu73L3ZxHcMroTuCinZmsF8GryPngIOiQBLA+fP0zQwvE1gp73pwAvCte15B16n7tn8pYtB4odiqgn7/fxAseQ9CnlPdTr7pN5y6bf+9MX8lLeU4cI6xE/D/wkjOMU4CkzxCPVQddtXbeleLpmx0A137Nw9ykz+wXwbDNr8rB+0N2ngI0AZvaCmV5exCGmL/QrCYbBIuf3eXH3nWb23wRDWa0nqL06QPBN9qMzvGz6G+rLgSvc/QPTK8ysfaZDFVi2n0f/A0ptKuU9tMzMGvMu5tPv/R3h80LfUy8HbnT3t+bEs67AdmME9a35lhP8/5GU0HVb120pia7ZMVDL99w+BnQx8wVwIX4LZIGX5i1/eTEvtpkniTghfJ7uUf8j4PHA3e6+scBjukNNK0HLSq7ziokl9GPgFDN7QgmvkepSynuoHnhx3rKXE9xinL6Q/xh4wSzv9XLF8zCw0sy6pxeY2TFU0W3OGqPrdvF03a5tumbHQC3fc3D3G83sQuAjZvZ4gs4EDxHc/jiO4I03THEtJvn7vs/MrgTeFw7XdBtBvdSZRe7iLjP7CUFd4EMEPZHPBF4HfMvdp+uk3kPQkvILM/sssBVYBpwEHO3u/xBu9yOCXvh3EvRkfhHBhBTF+iTwd8BPzOwDBLdRuwh6zb/O3QdL2JekUynvoUHgY2bWRdAj/hXAswg6rE3/f7qI4D39GzP7ULjPw4Hnuvsri4zn7Wb2ToL/A38FvKTAdv8LvB/4mpl9guB9+w6CVhxJGV23dd2WoumaHQMl30Vw94+Z2a+BNwEfAroJbnncRzDszhcL1NEV67UEPYPfRnAL5acEF8JfFfHafyd4k7+P4NZPBrgfuBD4VE78j5jZBoK6run4DxB0lrk8Z3//DBhBJyAIPhxeQfAfYE7u3mdmTyUYrupCgts/e8K/qdQhvySdSnkPDRAkQZ8GHkfwXnmTu//pPenuW83sKQTvqQ8TzFC4A7i6yHjeB3QQDNXWAvwceA4Hlwvg7pvN7CXhcb5H8P/oXwiG3JIU0nVb120piq7ZMTCfs2O3iIiIiIiUg2q+RUREREQiouRbRERERCQiSr5FRERERCKi5FtEREREJCJKvkVEREREIqLkW0REREQkIkq+RcrIzG4ys60RH3Ormd0U5TFFRKqBrtkSByXfUjXM7DQz8/Dx2Rm2WWFmE+E2N83zOOea2ZsXEquISK3TNVtqlZJvqUZjwN+ZWXOBda8imM1ragH7Pxd48wJeLyIij9I1W2qKkm+pRt8FlgFnFVh3HsH0ueORRiQiIjPRNVtqipJvqUa3A3cQXLT/xMxOAR4LfLXQi8xsg5l918z2m9m4md1nZv9uZg0522wFngEclXO71M3stLx9HWZmV5lZr5mNmNn1ZnZcgWN2mdnnzGxbeGt1W/j78gLbrjGzb5lZv5kNmNn3zeyYks+OiEiy6JotNaVh7k1EUulS4BNmdri77wiX/QOwF/hB/sZm9nzgO8Bm4ONAD3Aq8D7gZOBvw03fDHwY6ALekrOLe3N+bgN+AdwCvBNYB7wJuNrMTnL3THjMpcBvgGPDeG8Hngi8HvgrMzvF3QfDbTvCfa4BvgjcQ/CB8jNgUYnnRkQkaXTNltrh7nroURUP4DTAgbcBywluU74zXLcI6AP+M/x9CLgp/LkF2E1woWzI2+dbwn2elrPsJmDrDDHcFG7/b3nL/zVc/pycZR8Ml/1T3rZvCJe/P2fZh8Jl5+Vt+6lw+U1xn3899NBDj1IeumbH/2+gRzwPlZ1IVXL3A8A1BB1tAF4ELCVorcj3bGAlwa3NjvC2YpeZdRHUGgKcUcLhs8Bn8pb9NHxen7PsbGAfcEnetl8Kl5+ds+yFwB7girxtP1pCXCIiiaRrttQSlZ1INfsqcK2Z/SXB7ctb3f2eAtudGD4XushPW1nCcXe6+1jesgPhc25d4Dpgo7sf1Ivf3afM7H7gSTmLjwZu8/D2Z862u8ysr4TYRESSStdsqQlKvqWaXQ/sAC4CnklQl1eIhc//CmyaYZudJRw3M8s6m2WdiEgt0zVbaoKSb6la7p4xsyuAdwCjwFUzbPpA+Dzs7j8pZtfliA/YAhxvZg25LSlhT/3jwvW52643s/rclhQzWw10lCkeEZHY6JottUI131Ltvgi8F3iduw/MsM31BD3qLzSzzvyVZrbIzBbnLBoClpnZQltEvgd0A6/JW/6P4fLv5iy7muA26qvztn37AmMQEUkSXbOl6qnlW6qauz8CXDzHNsNm9mqCC+t9ZnYpwfBVHcAJBB1/ziboFQ/BcFQvAD5rZr8huGX5U3ffW2J4HyMYDutzZvYk4PcEw1adD9wXrs/d9u+AL5vZnwF3E4wUcCqwv8Tjiogkkq7ZUguUfIsA7n69mf05cCHwSoJWjF7gQeATBBNATPskQWealwCvI7iD9EyClphSjtlvZk8laOX5G4IJJvYQtPxc5OF4seG2vWb2tDCW6ZaUn4fHvbGkP1ZEJOV0zZY0M/dylUKJiIiIiMhsVPMtIiIiIhIRJd8iIiIiIhFR8i0iIiIiEhEl3yIiIiIiEVHyLSIiIiISESXfIiIiIiIRUfItIiIiIhIRJd8iIiIiIhFR8i0iIiIiEhEl3yIiIiIiEfn/m01wVrGh0t8AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 864x432 with 2 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "fig, axes = plt.subplots(ncols=2, figsize=(12, 6))\n",
+    "\n",
+    "axes[0].set_title('Tau Estimates', size=20)\n",
+    "axes[0].violinplot(knee_freqs_grid.mean(axis=1))\n",
+    "axes[0].violinplot(convert_knee_val(taus_abs), positions=[2])\n",
+    "\n",
+    "axes[0].axhline(10, color='k', ls='--')\n",
+    "\n",
+    "axes[0].set_xticks(ticks=[1, 2], labels=['Grid Search', 'abcTau'], size=16)\n",
+    "axes[0].set_ylabel('Tau (hertz)', size=18)\n",
+    "axes[0].set_xlabel('Method', size=18)\n",
+    "\n",
+    "\n",
+    "axes[1].set_title('Computation Time', size=20)\n",
+    "axes[1].violinplot(times * n_iters)\n",
+    "axes[1].violinplot(times_abc * n_iters, positions=[2])\n",
+    "\n",
+    "axes[1].set_xticks(ticks=[1, 2], labels=['Grid Search', 'abcTau'], size=16)\n",
+    "axes[1].set_ylabel('Time (seconds)', size=18)\n",
+    "axes[1].set_xlabel('Method', size=18)"
    ]
   }
  ],


### PR DESCRIPTION
This notebook checks if hyperparameter gridsearch can be used to minimize finite duration bias. Results show that taking the mean timescale of a grid of parameters significantly reduces finite duration bias. Specifically bias from 1s simulations approaches a comparable timescale variance as from 10s simulations, when the mean of the grid is taken. This means gridsearch could be an alternative to Zeraati 2021, which uses a Bayesian model to reduce bias. Both methods are slow, but direct comparison may be useful to see which method performs better.

The grid could be further explored to determine which hyperparamaters are most useful for reducing bias. Eliminating parameters that aren't useful could speed up computation time or accuracy.